### PR TITLE
Add pytest tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,13 @@ This project uses [`uv`](https://github.com/astral-sh/uv) as the package manager
    python3 complete-voice-chatbot.py
    ```
 
+## Running Tests
+
+Execute the test suite using `pytest`:
+
+```sh
+pytest
+```
+
 ## License
 MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,5 @@ dependencies = [
 [tool.uv]
 dev-dependencies = [
     "ruff>=0.11.12",
+    "pytest>=8.2.0",
 ]

--- a/tests/test_get_response.py
+++ b/tests/test_get_response.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch, Mock
+
+import pytest
+
+# Allow importing modules from the project root
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from step3_get_response import get_response
+
+
+def test_get_response_returns_expected_text():
+    sample_json = {
+        "id": "resp_123",
+        "output_text": "Hello world",
+    }
+    mock_resp = Mock()
+    mock_resp.json.return_value = sample_json
+    with patch("step3_get_response.requests.post", return_value=mock_resp):
+        text, resp_id = get_response("hello")
+    assert text == "Hello world"
+    assert resp_id == "resp_123"


### PR DESCRIPTION
## Summary
- add dev dependency for pytest
- document how to run tests in README
- test `get_response` with mocked `requests.post`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6842a55a2b3c83308b40c0f098b7dde6