### PR TITLE
Fix instructions typo

### DIFF
--- a/complete-voice-chatbot.py
+++ b/complete-voice-chatbot.py
@@ -29,7 +29,7 @@
 #     payload = {
 #         "model": "gpt-4o",
 #         "input": text,
-#         "instructions": "You are siri. You understnad indian english accent and replies with minimal words. All the input is strictly in english."
+#         "instructions": "You are siri. You understand indian english accent and replies with minimal words. All the input is strictly in english."
 #     }
     
 #     if previous_response_id:

--- a/step3_get_response.py
+++ b/step3_get_response.py
@@ -10,7 +10,7 @@ def get_response(input_text):
     payload = {
         "model": "gpt-4o",
         "input": input_text,
-        "instructions": "You are siri. You understnad indian english accent and replies with minimal words.",
+        "instructions": "You are siri. You understand indian english accent and replies with minimal words.",
     }
     
     response = requests.post(


### PR DESCRIPTION
## Summary
- fix `understand` typo in the simple response step
- update instructions comment in `complete-voice-chatbot.py`

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6842a50930b08330a38571ea11d27e1a